### PR TITLE
Vuex unsubscribe on unmount

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -17,6 +17,10 @@ export default (
       this.store = props[STORE_KEY] || context[STORE_KEY];
       this.mappedState = mapStateToPropsFn && mapStateToPropsFn(this.store.state, props);
       this.mappedGetters = mapGetterToPropsFn && mapGetterToPropsFn(this.store.getters, props);
+
+      // will be used to unsubscribe from store changes when the component unmounts
+      this.unsubscribeFn = null;
+
       this.state = Object.assign(
         {},
         this.mappedState,
@@ -24,8 +28,11 @@ export default (
         mapCommitToPropsFn && mapCommitToPropsFn(this.store.commit, props),
         this.mappedGetters,
       );
+    }
+
+    componentDidMount() {
       if (this.mappedState) {
-        this.store.subscribe((mutation, state) => {
+        this.unsubscribeFn = this.store.subscribe((mutation, state) => {
           let newState = {};
           // update state from store state
           const newMappedState = mapStateToPropsFn(state, this.props);
@@ -47,6 +54,12 @@ export default (
             this.setState(newState);
           }
         });
+      }
+    }
+
+    componentWillUnmount() {
+      if (typeof this.unsubscribeFn === 'function') {
+        this.unsubscribeFn();
       }
     }
 

--- a/test/unit/components/connect.spec.js
+++ b/test/unit/components/connect.spec.js
@@ -105,6 +105,8 @@ describe('connect', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should works without mapping', () => {
@@ -124,6 +126,8 @@ describe('connect', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should works calling mapStateToPropsFn', () => {
@@ -143,6 +147,8 @@ describe('connect', () => {
     expect(instance.state).toEqual({});
     expect(mapStateToPropsFn).toHaveBeenCalledWith(store.state, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should works calling mapGetterToPropsFn', () => {
@@ -162,6 +168,8 @@ describe('connect', () => {
     expect(instance.state).toEqual({});
     expect(mapGetterToPropsFn).toHaveBeenCalledWith(store.getters, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should works calling mapDispatchToPropsFn', () => {
@@ -181,6 +189,8 @@ describe('connect', () => {
     expect(instance.state).toEqual({});
     expect(mapDispatchToPropsFn).toHaveBeenCalledWith(store.dispatch, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should works calling mapCommitToPropsFn', () => {
@@ -200,6 +210,8 @@ describe('connect', () => {
     expect(instance.state).toEqual({});
     expect(mapCommitToPropsFn).toHaveBeenCalledWith(store.commit, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should subscribe to the store if has a mappedState', () => {
@@ -219,6 +231,8 @@ describe('connect', () => {
     expect(instance.state).toEqual({});
     expect(mapStateToPropsFn).toHaveBeenCalledWith(store.state, instance.props);
     expect(store.subscribe).toHaveBeenCalled();
+
+    component.unmount();
   });
 
   test('should work with real store mutations', () => {
@@ -259,6 +273,13 @@ describe('connect', () => {
     store.commit('inc');
     expect(instance.state.myCount).toBe(13);
     expect(instance.state.myCount2).toBe(25);
+
+    jest.spyOn(console, 'error');
+    component.unmount();
+    store.commit('inc');
+    expect(console.error).not.toHaveBeenCalled();
+
+    console.error.mockRestore();
   });
 
   test('should work with real store mutations and getters', () => {
@@ -317,5 +338,12 @@ describe('connect', () => {
     expect(instance.state.isGreaterThan2).toBeDefined();
     tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+
+    jest.spyOn(console, 'error');
+    component.unmount();
+    store.commit('inc');
+    expect(console.error).not.toHaveBeenCalled();
+
+    console.error.mockRestore();
   });
 });

--- a/test/unit/components/connect.spec.js
+++ b/test/unit/components/connect.spec.js
@@ -14,7 +14,7 @@ describe('connect', () => {
     state: {
       count: 12,
     },
-    subscribe: jest.fn(),
+    subscribe: jest.fn().mockReturnValue('foo'),
     getters: 'getters',
     dispatch: 'dispatch',
     commit: 'commit',
@@ -106,6 +106,7 @@ describe('connect', () => {
     expect(tree).toMatchSnapshot();
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -127,6 +128,7 @@ describe('connect', () => {
     expect(tree).toMatchSnapshot();
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -148,6 +150,7 @@ describe('connect', () => {
     expect(mapStateToPropsFn).toHaveBeenCalledWith(store.state, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -169,6 +172,7 @@ describe('connect', () => {
     expect(mapGetterToPropsFn).toHaveBeenCalledWith(store.getters, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -190,6 +194,7 @@ describe('connect', () => {
     expect(mapDispatchToPropsFn).toHaveBeenCalledWith(store.dispatch, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -211,6 +216,7 @@ describe('connect', () => {
     expect(mapCommitToPropsFn).toHaveBeenCalledWith(store.commit, instance.props);
     expect(store.subscribe).not.toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBeNull();
     component.unmount();
   });
 
@@ -232,7 +238,10 @@ describe('connect', () => {
     expect(mapStateToPropsFn).toHaveBeenCalledWith(store.state, instance.props);
     expect(store.subscribe).toHaveBeenCalled();
 
+    expect(instance.unsubscribeFn).toBe('foo');
+    instance.unsubscribeFn = jest.fn();
     component.unmount();
+    expect(instance.unsubscribeFn).toHaveBeenCalledWith();
   });
 
   test('should work with real store mutations', () => {
@@ -275,6 +284,7 @@ describe('connect', () => {
     expect(instance.state.myCount2).toBe(25);
 
     jest.spyOn(console, 'error');
+    expect(typeof instance.unsubscribeFn).toBe('function');
     component.unmount();
     store.commit('inc');
     expect(console.error).not.toHaveBeenCalled();
@@ -340,6 +350,7 @@ describe('connect', () => {
     expect(tree).toMatchSnapshot();
 
     jest.spyOn(console, 'error');
+    expect(typeof instance.unsubscribeFn).toBe('function');
     component.unmount();
     store.commit('inc');
     expect(console.error).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Ensure components that subscribe to `vuex` store changes also unsubscribe when they are no longer needed.

## Changes
- The `connect.js` HOC saves the unsubscribe function returned by the `vuex` `store.subscribe()` API, which is then used to clean up this listener during `componentWillUnmount()`.
- The `connect.js` HOC will now subscribe to the store changes during `componentDidMount()` (instead of the constructor). Note that it still gets its initial state within the `constructor()`.

## Related issue
- #24

## Testing
I've made 2 commits here. The first updates the unit tests to show the issue. If you checkout the first changeset and run `npm test`, React will log an error to the console. I've set a test expectation so that this causes a test failure. 

The second commit is the fix for the issue. Running the same tests on the final changeset does not log any error and the tests should pass.